### PR TITLE
Bump valkey from 8.0 to 8.1 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         ports:
           - 6372:6379
       valkey8:
-        image: valkey/valkey:8.0-alpine
+        image: valkey/valkey:8.1-alpine
         ports:
           - 6380:6379
 


### PR DESCRIPTION
## Summary
- Bump valkey Docker image from 8.0-alpine to 8.1-alpine in CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)